### PR TITLE
Use U+02B9 Modifier Letter Prime to stress syllables

### DIFF
--- a/src/epub/text/chapter-23.xhtml
+++ b/src/epub/text/chapter-23.xhtml
@@ -44,17 +44,17 @@
 			<p>Poorgrass, thus assured, trilled forth a flickering yet commendable piece of sentiment, the tune of which consisted of the key-note and another, the latter being the sound chiefly dwelt upon. This was so successful that he rashly plunged into a second in the same breath, after a few false starts:⁠—</p>
 			<blockquote epub:type="z3998:song">
 				<p>
-					<span>I sow′-ed th′-e⁠ ⁠…</span>
+					<span>I sowʹ-ed thʹ-e⁠ ⁠…</span>
 					<br/>
-					<span>I sow′-ed⁠ ⁠…</span>
+					<span>I sowʹ-ed⁠ ⁠…</span>
 					<br/>
-					<span>I sow′-ed th′-e seeds′ of′ love′,</span>
+					<span>I sowʹ-ed thʹ-e seedsʹ ofʹ loveʹ,</span>
 					<br/>
-					<span class="i1">I-it was′ all′ i′-in the′-e spring′,</span>
+					<span class="i1">I-it wasʹ allʹ iʹ-in theʹ-e springʹ,</span>
 					<br/>
-					<span>I-in A′-pril′, Ma′-ay, a′-nd sun′-ny′ June′,</span>
+					<span>I-in Aʹ-prilʹ, Maʹ-ay, aʹ-nd sunʹ-nyʹ Juneʹ,</span>
 					<br/>
-					<span class="i1">When sma′-all bi′-irds they′ do′ sing.</span>
+					<span class="i1">When smaʹ-all biʹ-irds theyʹ doʹ sing.</span>
 				</p>
 			</blockquote>
 			<p>“Well put out of hand,” said Coggan, at the end of the verse. “ ‘They do sing’ was a very taking paragraph.”</p>
@@ -63,9 +63,9 @@
 			<p>“Go on, Joseph⁠—go on, and never mind the young scamp,” said Coggan. “ ’Tis a very catching ballet. Now then again⁠—the next bar; I’ll help ye to flourish up the shrill notes where yer wind is rather wheezy:⁠—</p>
 			<blockquote epub:type="z3998:song">
 				<p>
-					<span>Oh the wi′-il-lo′-ow tree′ will′ twist′,</span>
+					<span>Oh the wiʹ-il-loʹ-ow treeʹ willʹ twistʹ,</span>
 					<br/>
-					<span>And the wil′-low′ tre′-ee wi′-ill twine′.</span>
+					<span>And the wilʹ-lowʹ treʹ-ee wiʹ-ill twineʹ.</span>
 				</p>
 			</blockquote>
 			<p>But the singer could not be set going again. Bob Coggan was sent home for his ill manners, and tranquility was restored by Jacob Smallbury, who volunteered a ballad as inclusive and interminable as that with which the worthy toper old Silenus amused on a similar occasion the swains Chromis and Mnasylus, and other jolly dogs of his day.</p>

--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -138,9 +138,9 @@
 			<p>“ ’Tis a pity that playing the flute should make a man look such a scarecrow,” observed <abbr>Mr.</abbr> Mark Clark, with additional criticism of Gabriel’s countenance, the latter person jerking out, with the ghastly grimace required by the instrument, the chorus of “Dame Durden:”⁠—</p>
 			<blockquote epub:type="z3998:song">
 				<p>
-					<span>’Twas Moll′ and Bet′, and Doll′ and Kate′,</span>
+					<span>’Twas Mollʹ and Betʹ, and Dollʹ and Kateʹ,</span>
 					<br/>
-					<span class="i1">And Dor′⁠—othy Drag′⁠—gle Tail’.</span>
+					<span class="i1">And Dorʹ⁠—othy Dragʹ⁠—gle Tail’.</span>
 				</p>
 			</blockquote>
 			<p>“I hope you don’t mind that young man’s bad manners in naming your features?” whispered Joseph to Gabriel.</p>


### PR DESCRIPTION
The current text uses U+2032 which is a mathematical prime; Unicode [comments it as](https://unicode.org/charts/PDF/U2000.pdf) “minutes, feet.” U+02B9 is [commented as](https://unicode.org/charts/PDF/U02B0.pdf) “primary stress, emphasis.”